### PR TITLE
V1.1 update

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "wordsmith/sdk"
+require_relative "../lib/wordsmith-ruby-sdk"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/wordsmith/project.rb
+++ b/lib/wordsmith/project.rb
@@ -1,5 +1,5 @@
 class Wordsmith::Project
-  attr_reader :name, :slug, :templates
+  attr_reader :name, :slug, :schema, :templates
 
   def self.all
     projects_attributes = Wordsmith.client.get 'projects'
@@ -11,20 +11,13 @@ class Wordsmith::Project
     project or fail %Q(Project not found with slug: "#{slug}")
   end
 
-  def schema
-    @_schema ||=
-      begin
-        body = Wordsmith.client.get "projects/#{slug}"
-        body[:schema]
-      end
-  end
-
   private
 
-  def initialize(name: nil, slug: nil, templates: nil)
-    raise "Missing required kword arguments" unless [name, slug, templates].all?
+  def initialize(name: nil, slug: nil, schema: nil, templates: nil, **attributes)
+    raise "Missing required keyword arguments" unless [name, slug, templates].all?
     @name = name
     @slug = slug
+    @schema = schema
     @templates = Wordsmith::TemplateCollection.new(
       templates.map {|t| Wordsmith::Template.new project: self, **t})
   end

--- a/lib/wordsmith/template.rb
+++ b/lib/wordsmith/template.rb
@@ -2,7 +2,7 @@ class Wordsmith::Template
   attr_reader :name, :slug, :project
 
   def initialize(name: nil, slug: nil, project: nil, **attributes)
-    raise "Missing required kword arguments" unless [name, slug, project].all?
+    raise "Missing required keyword arguments" unless [name, slug, project].all?
     @name = name
     @slug = slug
     @project = project

--- a/lib/wordsmith/template.rb
+++ b/lib/wordsmith/template.rb
@@ -1,7 +1,7 @@
 class Wordsmith::Template
   attr_reader :name, :slug, :project
 
-  def initialize(name: nil, slug: nil, project: nil)
+  def initialize(name: nil, slug: nil, project: nil, **attributes)
     raise "Missing required kword arguments" unless [name, slug, project].all?
     @name = name
     @slug = slug


### PR DESCRIPTION
#### What does this PR do?

Updates to the SDK to prepare the way for v1.1 of the Wordsmith API.  It appears the way the gem was previously coded, the changes being introduced in the Wordsmith API in v1.1 will break the gem.  The additional elements aren't expected by the `Project` class.  This update also resolves that issue so future elements can be added to the API without causing a break here.  We will want to release this gem at the same time the v1.1 API is released to Wordsmith.

We can bump the version number of this gem after the PR is accepted.
#### Impacted areas in application
- `Wordsmith::Project`
- `Wordsmith::Template`
#### Steps to test?
- Unit tests: `rake test`
  - All but one test pass (`ProjectTest#test_schema`).  This is because the tests run against the production API.  You can test against the v1.1 API locally with a few changes:
  - In the Wordsmith repo, pull the most recent development branch and start a server on port 3000.
  - Change the API key and add the URL in the test files (project_test.rb, template_test.rb, template_collection_test.rb):
    
    ```
    Wordsmith.configure do |config|
      config.token = YOUR_API_KEY
      config.url = "http://localhost:3000/v1"
    end
    ```
  - In Wordsmith, create a project named "test" with a template named "test".  The data should include 3 column titled "a", "b", and "c" which contain Number data.
- Manual tests:
  - In the Wordsmith repo, pull the most recent development branch and start a server on port 3000.
  - Open a console with the gem loaded by running `bin/console` in your terminal from the gem root.
  - Configure the gem to point to your local Wordsmith API and set your API key.  This is done the same way as above with the `Wordsmith.configure` lines.
  - Run `projects = Wordsmith::Project.all` and verify that projects load with templates and schema attributes.
  - Run `project = Wordsmith::Project.find('test')` and verify the project has templates and schema.
  - Run `project.schema` and verify schema hash is returned.
  - Run `project.templates` and verify template collection is returned.
##### What are the relevant outstanding Pull Requests?
- None
