### PR TITLE
BUG FIX:  400 error returns body[:errors] rather than (nonexistent) body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [Unreleased](https://github.com/automatedinsightsinc/wordsmith-ruby-sdk/compare/v1.0.4...HEAD)
 
+## [1.0.5](https://github.com/automatedinsightsinc/wordsmith-ruby-sdk/compare/v1.0.4...v1.0.5)
+##### Changed
+- Return :errors from Wordsmith when HTTP response code is 400 
+
 ## [1.0.4](https://github.com/automatedinsightsinc/wordsmith-ruby-sdk/compare/v1.0.3...v1.0.4)
 ##### Added
 - Handled HTTP 429

--- a/lib/wordsmith/client.rb
+++ b/lib/wordsmith/client.rb
@@ -42,7 +42,7 @@ module Wordsmith
       when 200, 201
         return body[:data]
       when 400
-        fail %Q(Bad Request: "#{body[:error]}")
+        fail %Q(Bad Request: "#{body[:errors]}")
       when 401
         fail 'API authorization error'
       when 429

--- a/lib/wordsmith/version.rb
+++ b/lib/wordsmith/version.rb
@@ -1,3 +1,3 @@
 module Wordsmith
-  VERSION = '1.0.4'
+  VERSION = '1.0.5'
 end


### PR DESCRIPTION
## What This PR Does

400 Errors only ever return 

```
RuntimeError: Bad Request: ""
```

This is because line 45 of `client.rb` is trying to find the `:error` node of the response `body`, which doesn't exist. The node is actually `errors`:

```
{:errors=>[{:detail=>ERROR DETAIL}]}
```

This PR retrieves the error detail from the body.

## To Test

In an IRB session, trigger a 400 response by calling `#generate` on a `Template` instance using bad data, such as `{"bad"=> "data"}`.  Notice how there is no useful error output. Then, switch to this branch and do the same. 